### PR TITLE
Feature9 add readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 
 # Anonlink Client
 
-Client-face API to interact with anonlink system including command line tools and Rest API communication.
+Client-facing API to interact with anonlink system including command line tools and Rest API communication.
 Anonlink system needs the following three components to work together:
 
-* <a href='https://github.com/data61/clkhash'>clkhash</a>
-* <a href='https://github.com/data61/blocklib'>blocklib</a>
-* <a href='https://github.com/data61/anonlink-entity-service'>anonlink-entity-service</a>
+* [clkhash](https://github.com/data61/clkhash)
+* [blocklib](https://github.com/data61/blocklib)
+* [anonlink-entity-service](https://github.com/data61/anonlink-entity-service)
 
 This package provides an easy to use API to interact with the above packages to complete a record linkage job.
 
@@ -23,16 +23,16 @@ pip install git+https://https://github.com/data61/clkhash
 
 ### Documentation
 https://clkhash.readthedocs.io/en/stable/cli.html
-
+Note that the documentation are for clkhash now, we will add a readthedocs page for anonlink-client very soon.
 
 ### CLI Tool
-After installation, you should have a `anonlink` program in your path. Alternatively, you can use `client.cli`. For
+After installation, you should have a `anonlink` program in your path. For
 example, to hash PII data  `alice.csv` locally with schema `schema.json` and secret `horse`, run:
 ```bash
 $ anonlink hash 'alice.csv' 'horse' 'schema.json' 'clk.json'
 ```
 
 It will generate the CLK output and store in `clk.json`. To find out how to define the schema
-for your PII data, please refer <a href='https://clkhash.readthedocs.io/en/stable/schema.html'>this page</a> for 
+for your PII data, please refer [this page](https://clkhash.readthedocs.io/en/stable/schema.html) for 
 details.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Anonlink system needs the following three components to work together:
 
 This package provides an easy to use API to interact with the above packages to complete a record linkage job.
 
-The way to interact with anonlink system is via Command Line Tool `anonlink`. You can hash data containing PII (Personal Identifying Information) locally using `anonlink hash`, generate candidate blocks locally to scale up record linkage using `anonlink block`, create a record linkage job in entity service with `anonlink create-project` etc.
+The way to interact with anonlink system is via Command Line Tool `anonlink`. You can hash data containing PII (Personal
+ Identifying Information) locally using `anonlink hash`, generate candidate blocks locally to scale up record linkage 
+ using `anonlink block`, create a record linkage job in entity service with `anonlink create-project` etc.
 
 ### Installation
 Currently manual install:
@@ -20,9 +22,17 @@ pip install git+https://https://github.com/data61/clkhash
 ```
 
 ### Documentation
-https://clkhash.readthedocs.io 
+https://clkhash.readthedocs.io/en/stable/cli.html
 
 
 ### CLI Tool
-After installation, you should have a `anonlink` program in your path. Alternatively, you can use `client.cli`. As 
-mentioned earlier, it can achieve many
+After installation, you should have a `anonlink` program in your path. Alternatively, you can use `client.cli`. For
+example, to hash PII data  `alice.csv` locally with schema `schema.json` and secret `horse`, run:
+```bash
+$ anonlink hash 'alice.csv' 'horse' 'schema.json' 'clk.json'
+```
+
+It will generate the CLK output and store in `clk.json`. To find out how to define the schema
+for your PII data, please refer <a href='https://clkhash.readthedocs.io/en/stable/schema.html'>this page</a> for 
+details.
+

--- a/README.md
+++ b/README.md
@@ -1,29 +1,28 @@
 
-# Blocking POC 
+# Anonlink Client
 
-A simple end to end demonstrator of blocking for record linkage.
+Client-face API to interact with anonlink system including command line tools and Rest API communication.
+Anonlink system needs the following three components to work together:
 
-Output should be candidate blocks.
+* <a href='https://github.com/data61/clkhash'>clkhash</a>
+* <a href='https://github.com/data61/blocklib'>blocklib</a>
+* <a href='https://github.com/data61/anonlink-entity-service'>anonlink-entity-service</a>
 
+This package provides an easy to use API to interact with the above packages to complete a record linkage job.
+
+The way to interact with anonlink system is via Command Line Tool `anonlink`. You can hash data containing PII (Personal Identifying Information) locally using `anonlink hash`, generate candidate blocks locally to scale up record linkage using `anonlink block`, create a record linkage job in entity service with `anonlink create-project` etc.
+
+### Installation
+Currently manual install:
+
+```python3
+pip install git+https://https://github.com/data61/clkhash
 ```
-{
-  'records': [clks],
-  'blocks': {
-      'block id 1': [record ids]
-  }
-}
-```
 
-Two methods have been implemented that map to a list of records.
+### Documentation
+https://clkhash.readthedocs.io 
 
-- index based blocking: creates a block for every high bit in the
-  blocking filter.
-- signature based blocking: creates a block for every individual
-  signature.
-  
-## Software Components
 
-- anonlink-client
-- blocklib
-- anonlink
-- clkhash
+### CLI Tool
+After installation, you should have a `anonlink` program in your path. Alternatively, you can use `client.cli`. As 
+mentioned earlier, it can achieve many

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The way to interact with anonlink system is via Command Line Tool `anonlink`. Yo
 Currently manual install:
 
 ```python3
-pip install git+https://https://github.com/data61/clkhash
+pip install git+https://https://github.com/data61/anonlink-client
 ```
 
 ### Documentation
@@ -29,7 +29,7 @@ Note that the documentation are for clkhash now, we will add a readthedocs page 
 After installation, you should have a `anonlink` program in your path. For
 example, to hash PII data  `alice.csv` locally with schema `schema.json` and secret `horse`, run:
 ```bash
-$ anonlink hash 'alice.csv' 'horse' 'schema.json' 'clk.json'
+$ anonlink hash 'alice.csv' 'horse' 'schema.json' 'encoded-entities.json'
 ```
 
 It will generate the CLK output and store in `clk.json`. To find out how to define the schema


### PR DESCRIPTION
In this pull request, I updated ReadMe with renovated anonlink-client as a client-face API to interact with anonlink system.

The documentation for CLI tools is comprehensive in clkhash readthedocs. So I pointed the documentation there. In the future, We might need to create a readthedocs for anonlink-client and migrate the docs from clkhash to anonlink-client.

Close #9 