### PR TITLE
Add click as a direct dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 anonlink == 0.12.5
+click == 7.1.1
 clkhash == 0.15.1
 jsonschema == 3.2.0
 numpy == 1.18.1

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,12 @@ from setuptools import setup, find_packages
 
 requirements = [
         "anonlink >= 0.12.5",
-        "clkhash >= 0.14.0",
-        "jsonschema >= 3.0.2",
-        "numpy >= 1.17.0",
-        "pandas >= 0.25.2",
-        "pytest >= 5.2.1",
+        "click >= 7.1.1",
+        "clkhash >= 0.15.0",
+        "jsonschema >= 3.2.0",
+        "numpy >= 1.18.1",
+        "pandas >= 1.0.1",
+        "pytest >= 5.3.5",
         "requests >= 2.22.0",
     ]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -271,7 +271,8 @@ class TestHashCommand(unittest.TestCase):
             result = runner.invoke(cli.cli,
                                    ['hash', 'in.csv'])
             assert result.exit_code != 0
-            self.assertIn('Missing argument "SECRET"', result.output)
+            self.assertIn('Usage: anonlink hash', result.output)
+            self.assertIn('Missing argument', result.output)
 
     def test_hash_with_provided_schema(self):
         runner = self.runner


### PR DESCRIPTION
Also fixes a test that was failing due to click's error message (it looked like a really big breaking change - the `"` had changed to a `'` in the Missing argument message)