### PR TITLE
Allow creation of a project that uses blocking

### DIFF
--- a/anonlinkclient/cli.py
+++ b/anonlinkclient/cli.py
@@ -256,12 +256,13 @@ After both users have uploaded their data one can watch for and retrieve the res
               help='Protocol/view type for the project.')
 @click.option('--schema', type=click.File('r'), help="Schema to publicly share with participating parties.")
 @click.option('--name', type=str, help="Name to give this project")
+@click.option('--blocked', type=bool, default=False, help="This project uses blocking")
 @click.option('--parties', default=2, type=int,
               help="Number of parties in the project")
 @click.option('-o', '--output', type=click.File('w'), default='-')
 @add_options(rest_client_option)
 @verbose_option
-def create_project(type, schema, name, parties, output, server, retry_multiplier, retry_max_exp,
+def create_project(type, schema, name, blocked, parties, output, server, retry_multiplier, retry_max_exp,
                    retry_stop, verbose):
     """Create a new project on an entity matching server.
 
@@ -285,7 +286,7 @@ def create_project(type, schema, name, parties, output, server, retry_multiplier
     try:
         rest_client = create_rest_client(server, retry_multiplier, retry_max_exp, retry_stop, verbose)
         project_creation_reply = rest_client.project_create(
-            schema_json, type, name, parties=parties)
+            schema_json, type, name, parties=parties, uses_blocking=blocked)
     except ServiceError as e:
         log("Unexpected response - {}".format(e.status_code))
         log(e.text)

--- a/anonlinkclient/rest_client.py
+++ b/anonlinkclient/rest_client.py
@@ -107,7 +107,7 @@ class RestClient:
         response = self.__request_wrapper('get', self.server + "/api/v1/status")
         return _handle_json_response(response, "Error with service status")
 
-    def project_create(self, schema, result_type, name, notes=None, parties=2):
+    def project_create(self, schema, result_type, name, notes=None, parties=2, uses_blocking=False):
         if notes is None:
             notes = 'Project created by clkhash version {}'.format(clkhash.__version__)
 
@@ -119,6 +119,7 @@ class RestClient:
                 'result_type': result_type,
                 'number_parties': parties,
                 'name': name,
+                'uses_blocking': uses_blocking,
                 'notes': notes
             }
         )


### PR DESCRIPTION
Blocking is an optional project level setting on the anonlink entity service, this change allows the creation of projects that have blocking enabled from the rest_api and command line tool.