### PR TITLE
Depend on blocklib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 anonlink == 0.12.5
+blocklib == 0.1.3
 click == 7.1.1
 clkhash == 0.15.1
 jsonschema == 3.2.0
@@ -7,7 +8,6 @@ pandas == 1.0.3
 pytest == 5.4.1
 requests == 2.23.0
 retrying==1.3.3
-blocklib==0.1.1
 pytest-cov==2.8.1
 pytest-azurepipelines==0.8.0
 pytest-timeout==1.3.4

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup, find_packages
 
 requirements = [
         "anonlink >= 0.12.5",
+        "blocklib >= 0.1.3",
         "click >= 7.1.1",
         "clkhash >= 0.15.0",
         "jsonschema >= 3.2.0",


### PR DESCRIPTION
Anonlink client uses blocklib, therefore it should have blocklib as a listed and pinned dependency.