### PR TITLE
fixed package name

### DIFF
--- a/anonlinkclient/__init__.py
+++ b/anonlinkclient/__init__.py
@@ -2,7 +2,7 @@ import pkg_resources
 from .rest_client import RestClient, ServiceError
 
 try:
-    __version__ = pkg_resources.get_distribution('anonlinkclient').version
+    __version__ = pkg_resources.get_distribution('anonlink-client').version
 except pkg_resources.DistributionNotFound:
     __version__ = "development"
 


### PR DESCRIPTION
we didn't grab the right package to extract the version number, thus it always defaulted to "development"