### PR TITLE
fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,14 @@ from setuptools import setup, find_packages
 
 requirements = [
         "anonlink >= 0.12.5",
-        "blocklib >= 0.1.3",
+        "blocklib >= 0.1.4",
         "click >= 7.1.1",
         "clkhash >= 0.16.0a1",
         "jsonschema >= 3.2.0",
-        "numpy >= 1.18.1",
-        "pandas >= 1.0.1",
-        "pytest >= 5.3.5",
         "requests >= 2.22.0",
+        "minio >= 5.0.10",
+        "bashplotlib >= 0.6.5",
+        "retrying>=1.3.3",
     ]
 
 with open('README.md', 'r', encoding='utf-8') as f:
@@ -18,13 +18,18 @@ with open('README.md', 'r', encoding='utf-8') as f:
 
 setup(
     name="anonlink-client",
-    version='0.1.3',
+    version='0.1.4-beta',
     description='Client side tool for clkhash and blocklib',
     long_description=readme,
     long_description_content_type='text/markdown',
     url='https://github.com/data61/anonlink-client',
     license='Apache',
     install_requires=requirements,
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest', 'pytest-cov', 'mock'],
+    extras_require={
+        "tutorials": ['numpy', 'pandas']
+    },
     packages=find_packages(exclude=['tests']),
     package_data={'anonlinkclient': ['data/*.csv', 'data/*.json', 'schemas/*.json']},
     project_urls={


### PR DESCRIPTION
declare all required dependencies, removed the ones only needed in the tutorials, moved the test dependencies to tests_require

currently, we are not declaring all required dependencies. Thus the client doesn't work when installed with pip.

after merging this, we need another release.