### PR TITLE
Sanity check on input type for block command

### DIFF
--- a/anonlinkclient/utils.py
+++ b/anonlinkclient/utils.py
@@ -73,15 +73,15 @@ def generate_candidate_blocks_from_csv(input_f: TextIO,
 
     # read from CSV file
     else:
-        # # sentinel check for input
-        # if suffix_input != 'csv':
-        #     raise TypeError(f'Upload should be CSVs not {suffix_input.upper()} file')
-        # else:
-        reader = unicode_reader(input_f)
-        if header:
-            next(reader)
-        for line in reader:
-            pii_data.append(tuple(element.strip() for element in line))
+        # sentinel check for input
+        if suffix_input == 'json':
+            raise TypeError(f'Upload should be CSVs not CLKs')
+        else:
+            reader = unicode_reader(input_f)
+            if header:
+                next(reader)
+            for line in reader:
+                pii_data.append(tuple(element.strip() for element in line))
 
     # generate candidate blocks
     blocking_obj = generate_candidate_blocks(pii_data, blocking_config, verbose=verbose)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,6 +39,12 @@ class TestUtils(unittest.TestCase):
             generate_candidate_blocks_from_csv(input_f, input_f, True)
 
     def test_sentinel_check(self):
+        # check p-sig with clks upload
+        input_f = open(os.path.join(TESTDATA, 'small_clk.json'), 'r')
+        schema_f = open(os.path.join(TESTDATA, 'p-sig-schema.json'), 'r')
+        with self.assertRaises(TypeError) as e:
+            generate_candidate_blocks_from_csv(input_f, schema_f)
+            assert e == 'Upload should be CSVs not CLKs'
         # check lambda-fold specified input-clks being true with csv upload
         csv_f = open(os.path.join(TESTDATA, 'dirty_1000_50_1.csv'), 'r')
         schema = json.load(open(os.path.join(TESTDATA, 'lambda_fold_schema.json'), 'r'))


### PR DESCRIPTION
Throw exception when feeding CLKs to P-sig blocking or lambda-fold when input-clks is False.

Close #74 