### PR TITLE
Remove anonlink dependency

### DIFF
--- a/docs/tutorial/tutorial-requirements.txt
+++ b/docs/tutorial/tutorial-requirements.txt
@@ -1,1 +1,2 @@
 anonlink-client>=0.0.1
+anonlink==0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-anonlink == 0.12.5
 bashplotlib == 0.6.5
 blocklib == 0.1.4
 click == 7.1.2

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import setup, find_packages
 
 
 requirements = [
-        "anonlink >= 0.12.5",
         "blocklib >= 0.1.4",
         "click >= 7.1.1",
         "clkhash >= 0.16.0a1",
@@ -28,7 +27,7 @@ setup(
     setup_requires=['pytest-runner'],
     tests_require=['pytest', 'pytest-cov', 'mock'],
     extras_require={
-        "tutorials": ['numpy', 'pandas']
+        "tutorials": ['numpy', 'pandas', 'anonlink']
     },
     packages=find_packages(exclude=['tests']),
     package_data={'anonlinkclient': ['data/*.csv', 'data/*.json', 'schemas/*.json']},


### PR DESCRIPTION
we don't need to install anonlink for the client. It is only needed in the notebooks.