### PR TITLE
Support minio 6

### DIFF
--- a/anonlinkclient/cli.py
+++ b/anonlinkclient/cli.py
@@ -19,8 +19,7 @@ from clkhash.serialization import serialize_bitarray, deserialize_bitarray
 from clkhash.schema import SchemaError, validate_schema_dict, convert_to_latest_version
 from minio import Minio
 from .progress import Progress
-from minio.credentials import Credentials, Chain, Static
-from minio.credentials.file_aws_credentials import FileAWSCredentials
+from minio.credentials import Credentials, Chain, Static, FileAWSCredentials
 
 from .rest_client import ClientWaitingConfiguration, ServiceError, format_run_status, RestClient
 

--- a/anonlinkclient/cli.py
+++ b/anonlinkclient/cli.py
@@ -405,7 +405,7 @@ def upload(clk_json, project, apikey, output, blocks, server, retry_multiplier, 
         object_store_credential_providers.append(
             Static(access_key=credentials['AccessKeyId'],
                    secret_key=credentials['SecretAccessKey'],
-                   token=credentials['SessionToken']))
+                   session_token=credentials['SessionToken']))
 
 
         mc = Minio(

--- a/anonlinkclient/progress.py
+++ b/anonlinkclient/progress.py
@@ -26,7 +26,7 @@ import sys
 import time
 from threading import Thread
 
-from minio.compat import queue, queue_empty
+from queue import Queue, Empty
 
 _BAR_SIZE = 20
 _KILOBYTE = 1024
@@ -68,7 +68,7 @@ class Progress(Thread):
         self.last_printed_len = 0
         self.current_size = 0
 
-        self.display_queue = queue()
+        self.display_queue = Queue()
         self.initial_time = time.time()
         self.stdout = stdout
         self.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ click == 7.1.2
 clkhash == 0.16.0b1
 jsonschema == 3.2.0
 numpy == 1.19.1
-minio == 5.0.10
+minio == 6.0.0
 pandas == 1.1.0
 pytest == 6.0.0
 requests == 2.24.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = [
         "clkhash >= 0.16.0b1",
         "jsonschema >= 3.2.0",
         "requests >= 2.22.0",
-        "minio >= 5.0.10",
+        "minio >= 6.0.0",
         "bashplotlib >= 0.6.5",
         "retrying>=1.3.3",
     ]


### PR DESCRIPTION
the new major release of minio has breaking changes which affect the anonlink client. This PR adjusts the relevant code to work with the new minio 6.0.0. 
This will also mean that from now on we have to insist on a version >= 6.0.0 in setup.py.