### PR TITLE
bitarray.length() is deprecated. 

### DIFF
--- a/anonlinkclient/cli.py
+++ b/anonlinkclient/cli.py
@@ -390,10 +390,10 @@ def upload(clk_json, project, apikey, output, blocks, server, retry_multiplier, 
         clks = json.load(f)['clks']
 
     hash_count = len(clks)
-    hash_size2 = (len(deserialize_bitarray(clks[0])) + 7) // 8
+    hash_size = (len(deserialize_bitarray(clks[0])) + 7) // 8
     encoding_metadata = {
         'hash-count': hash_count,
-        'hash-size': hash_size2
+        'hash-size': hash_size
     }
 
     if upload_to_object_store and not to_entityservice:

--- a/anonlinkclient/cli.py
+++ b/anonlinkclient/cli.py
@@ -390,10 +390,10 @@ def upload(clk_json, project, apikey, output, blocks, server, retry_multiplier, 
         clks = json.load(f)['clks']
 
     hash_count = len(clks)
-    hash_size = int(deserialize_bitarray(clks[0]).length() / 8)
+    hash_size2 = (len(deserialize_bitarray(clks[0])) + 7) // 8
     encoding_metadata = {
         'hash-count': hash_count,
-        'hash-size': hash_size
+        'hash-size': hash_size2
     }
 
     if upload_to_object_store and not to_entityservice:


### PR DESCRIPTION
we should use `len()` instead. Also, it seemed to me that the computation of number of bytes from the number of bits would not always return the correct result. E.g.: 9 bits need 2 bytes.

fixes #105