### PR TITLE
adjust to changed blocklib api

### DIFF
--- a/anonlinkclient/utils.py
+++ b/anonlinkclient/utils.py
@@ -128,7 +128,7 @@ def generate_candidate_blocks_from_csv(
 
     # step4 - add CLK counts and blocking statistics to metadata
     result["meta"]["source"] = {"clk_count": [len(pii_data)]}
-    result["meta"]["stats"] = blocking_obj.state.stats
+    result["meta"]["stats"] = blocking_obj.stats
 
     if verbose:
         blocking_obj.print_summary_statistics()

--- a/poetry.lock
+++ b/poetry.lock
@@ -255,153 +255,99 @@ lxml = ["lxml"]
 
 [[package]]
 name = "bitarray"
-version = "2.7.2"
+version = "2.7.3"
 description = "efficient arrays of booleans -- C extension"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "bitarray-2.7.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:823346ea803da6cfd4d67ffd04cc158ba1f016123c3e1fbdef893c6f13d5eddc"},
-    {file = "bitarray-2.7.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:79450ed20fb7f10e9fc5f1ebe5900748159afd5017275ece8c2be52b3b1c57bc"},
-    {file = "bitarray-2.7.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f3d2f0e7ac483b170e755d0776513127b0d68c36470f9d80cb8d5cdfcc8bcdbb"},
-    {file = "bitarray-2.7.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:714cdab2cfae514052791860946af0d5aaeb34b13065a0536b6701e6f1f21807"},
-    {file = "bitarray-2.7.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:934ed03695448e1676d4fca19e4c2508ced38ac32142a76c459125e335443ae3"},
-    {file = "bitarray-2.7.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:46de0402d5de5d65548827708726590d5f67884d78f04fc90e2b380ed96198d8"},
-    {file = "bitarray-2.7.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7021bf935c9dfe9a6d98aba2e60dd52e3611fba520c2ae76394c50c5b6dc1f46"},
-    {file = "bitarray-2.7.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b2a9f2104123e3124708c9f99daf59e2d71ca46c97ea9740554f2d3e96a059a7"},
-    {file = "bitarray-2.7.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:56ad19e34dcbbd6a80cbf45a31c202395def67579748813a6943f31507dd59be"},
-    {file = "bitarray-2.7.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:f18f29265a41f8c420e82530c0fda6cbac30032d2e2d1a36862f99fd400ce1c2"},
-    {file = "bitarray-2.7.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:ade050784d9e6a4a6a05601eaef01147943ef0a47599abd9af26ee99f9757aaa"},
-    {file = "bitarray-2.7.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:788538fd23db859472baf15e547112fb91dad987fb183d701192ee5d74b221dd"},
-    {file = "bitarray-2.7.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:499ca055ba6b61a1e6a961af9929dd67e3de0cfce362a4d57edd2da7668f7296"},
-    {file = "bitarray-2.7.2-cp310-cp310-win32.whl", hash = "sha256:998366fe820153ab3b5392b7f8f8885a6f621978f780d6c2eb9cfd57ae32ce3d"},
-    {file = "bitarray-2.7.2-cp310-cp310-win_amd64.whl", hash = "sha256:cd66dc118fd97214ac5f5a8ad89721ec7b598a64acb3f1c489bd76719c91bbdf"},
-    {file = "bitarray-2.7.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4daaf03c5f00c56d57d6c1df6fe3dcf5737691c8273ebd6c29e0067d26566a1c"},
-    {file = "bitarray-2.7.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f081ea4f9e15df0abdaebad8c80e650bf531e380fa631711243077b86b82dd8f"},
-    {file = "bitarray-2.7.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:29a9c8d8a423d7a72e4530ce8870bd9056a6ce4f07906895b395fcdb44fef377"},
-    {file = "bitarray-2.7.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbc4b4a2fc44f5c6d75546c96df4f89b5870ac6bc4e51b76d0dcb0d7f9e6ccb4"},
-    {file = "bitarray-2.7.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ab8e53945b7bbc287265cfb62d60f3525a1555189deab87c2ad4fda79cee3ac"},
-    {file = "bitarray-2.7.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:34c179e7845687125a582c1e46d92bff1eee2b2ee18190329699387324fb9dad"},
-    {file = "bitarray-2.7.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0061d7061ce1b3dccc5abced2bfb45298ef442d9e2b7993eef77cbc8b35afb1"},
-    {file = "bitarray-2.7.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a550c9e7ca35bebddc3585e844b0d973ee35b402dca5287e7837a105045f707"},
-    {file = "bitarray-2.7.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b53c34c913193e6f57bce9947170a81f58dd5bf07ea3b69fccade108ea590205"},
-    {file = "bitarray-2.7.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:5614eb025f246392c28b32bc60b62d1e3c2794e3dc03a06605fc33cff6192746"},
-    {file = "bitarray-2.7.2-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:ad2d9cca627ca1033a97ab26bd9039f6f89c45c9490dc99bce4172553caa6b6f"},
-    {file = "bitarray-2.7.2-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:2493ef17136c779b2842d3eeaff64133b8c28cf58c196e90af8d26ebaa06d7b6"},
-    {file = "bitarray-2.7.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:35df09a127333f7bdd5aa362c33ed1676545b78bf270b9258c6fdb2f994c3e6e"},
-    {file = "bitarray-2.7.2-cp311-cp311-win32.whl", hash = "sha256:2f65ad161a49e2ebb6249c11f60a62717c26261efeba0d4f78565853c159c9f3"},
-    {file = "bitarray-2.7.2-cp311-cp311-win_amd64.whl", hash = "sha256:9e100fc421660e06c2f4b7b534a04b7afcc3e988acf57c795fc3274611d1eae9"},
-    {file = "bitarray-2.7.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:acba84b9f53a4c363708291a7ae92bd74ac5a1bd07911e282dd8cef725e3d1ca"},
-    {file = "bitarray-2.7.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7d4132c5a290e9fb5b24819a55839e584433a92b7a9ae5bb8840ebbf01360dd9"},
-    {file = "bitarray-2.7.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e9e01564f13ff21fe1c0bc159b3e3c5d4de7f967b1c8bb8eb16fca1bb745950b"},
-    {file = "bitarray-2.7.2-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a939968a81d944b5a6fcbe1ff8fa40044c677549cae2e7e2c94bac7aec02a42d"},
-    {file = "bitarray-2.7.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae8ce3e62a868435daa107121fe2e3ef54d046de68c42e77820380e82d167cbb"},
-    {file = "bitarray-2.7.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3d0f62487a9e9f27fdb8a9e831d901cc28d7e99a0f1812256df688cec4b267f7"},
-    {file = "bitarray-2.7.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:c68b0fc1983704b877cd64e26ea8623b77fc5c7a0d501d15a0ce3905936485df"},
-    {file = "bitarray-2.7.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:5b1359da9071910d87ea0a0bac9eec933604238ae4cbfac9912137b00498416e"},
-    {file = "bitarray-2.7.2-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:ffb7c394e7b313bf74896d17143c287d2d055f738373409dcb28ed41d564edba"},
-    {file = "bitarray-2.7.2-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:7c978ac92e1ef230c6fea1175300261634def47966d2757b831300b0566fa3dc"},
-    {file = "bitarray-2.7.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:93c6bd3658fa997b5ad84a5bfecd8b4d3a8feef9da96ddbf9d83b2cb8fc0f8aa"},
-    {file = "bitarray-2.7.2-cp36-cp36m-win32.whl", hash = "sha256:ec9f24b31276e10441e2aec6a5d75cbb9670e82a1c14258cca505e8ef173e52a"},
-    {file = "bitarray-2.7.2-cp36-cp36m-win_amd64.whl", hash = "sha256:0d418c0b9df98ad4b2fe8e43c47e32571061d1258da5bc1381d67a5dc48c8928"},
-    {file = "bitarray-2.7.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3e973115d49fe996bbb1c1c3c9ef3bcb574fed143c28b710be694ea86c3fbe60"},
-    {file = "bitarray-2.7.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:698cbb06a243fcb01c21031860644568ae3e87d2f837a17f5565bc8b840ad886"},
-    {file = "bitarray-2.7.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a036c9cb40724f6ff81626a1159a3da9f57ee4d1b8448fc339cdca545e4f2313"},
-    {file = "bitarray-2.7.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dc9ce35a0e12ef9bd3da5985adb9d36e9fd16b2d94abfe00c117c492e427cb96"},
-    {file = "bitarray-2.7.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6adb9fe0c6ab4df89f4c3243aa9825add9f5e6581c879645a72eb707e7939276"},
-    {file = "bitarray-2.7.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b67aac815eb0f2b076cf60a6bc0185b01f5d2fef5996765cc8397d7829ec397a"},
-    {file = "bitarray-2.7.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:620c6d92914e19be959ee12b09d0fa7e653688565aeb4bd3ca8eef816ed6c105"},
-    {file = "bitarray-2.7.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:300eeb5e15aba56e25a1aa5df127709796f0ac6674974d0e44e396cde5928f6b"},
-    {file = "bitarray-2.7.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:295681a8b9a32bc12c08919e5c0fa80b69745771ae6f9eed3c1964f3d2c127a5"},
-    {file = "bitarray-2.7.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:deba5826868c8694538b469f605860ce1fec16e81cd36b0a081b69b79b899cae"},
-    {file = "bitarray-2.7.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:7368296a74a74c4b563ceca03d5ee86e25ab987f43cb833d0abffb183134e641"},
-    {file = "bitarray-2.7.2-cp37-cp37m-win32.whl", hash = "sha256:e3cb66abca1db3a3a97c67557c247e7f2ff5962d595262cb5c0dc9fdeb4b6ceb"},
-    {file = "bitarray-2.7.2-cp37-cp37m-win_amd64.whl", hash = "sha256:add21aa6db4bfb43e4c038846332f183add249938acf14b19c9d28363921e79b"},
-    {file = "bitarray-2.7.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:668d3bfad265598c14428ae767509dcbf5f5e37fd759851b311ad26fa9de95d2"},
-    {file = "bitarray-2.7.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:169f8739bec3021f590979e02a19f85ea6ab59b77bd6dd9fb0071dde144ac1b6"},
-    {file = "bitarray-2.7.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:41318ef42fb2178551f1e323d6356872051cda420155df2ef646190b8736364c"},
-    {file = "bitarray-2.7.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d95e74e815a38a1ce8a4b4c23516cc60d40d30ec75550fb22ea37d23cf6439b"},
-    {file = "bitarray-2.7.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:15f420819542e061a5c3801287ab582d15b47a4cdd984c58f160d48755c86997"},
-    {file = "bitarray-2.7.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2ce7e716f116d2b857d50723166e307aae685ee7ffaef6e51c3bc9dfde099442"},
-    {file = "bitarray-2.7.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3c44bb59bcfa041f0b1a44d3a7e12c30d107b498d89e60c25b64e792a0fe917"},
-    {file = "bitarray-2.7.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:34b626d4b16a946eb374f3f1c7c216d6731a95325d728aa4d6f24947a6a77e38"},
-    {file = "bitarray-2.7.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:29b3a6690aed914142f8daae4429fa41932f16d609d0b49b5bedf6781638b3a9"},
-    {file = "bitarray-2.7.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:e7e152dd8d805d8950ffde3f004b1fc170f48ab2fab2410ecacbf74ee471fca7"},
-    {file = "bitarray-2.7.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:4ccd6e6d99fa9e7a78f00b6fde3db01c7963dbbfd775fba4e46a5c6a44768429"},
-    {file = "bitarray-2.7.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:0d9a10645bab89dc63ff33da53be3203358c434a6c8a47ab284bd3981b34c08c"},
-    {file = "bitarray-2.7.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:4b768d6826d4b8f00f0ee0910ee1236272bc9456a5ed6575e6e235719b773ee8"},
-    {file = "bitarray-2.7.2-cp38-cp38-win32.whl", hash = "sha256:8d577d9a4efbed15b732e98e7fa4d6b76f2591b4935855f52556e5dd61b4bf09"},
-    {file = "bitarray-2.7.2-cp38-cp38-win_amd64.whl", hash = "sha256:c532942da8d3f5ac189084b7944ec13245eaf18361f902ae44636492d4744189"},
-    {file = "bitarray-2.7.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2e41ab09b62b1d20c5b1f22ed63a69ab53cf48266ecaad7d6264064a90978754"},
-    {file = "bitarray-2.7.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d45271681c4da3b15967ef5c1f8c45c74d138cbffe4184638b4fdd1ace9ea7cf"},
-    {file = "bitarray-2.7.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e1249f3fc6a8cc6c2ab366afa4d057edea73cf96d37ca28c5268a7d2b03a4d83"},
-    {file = "bitarray-2.7.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f416ac15e8e4c0d6dfb1d50be971f7aa605959844f2190f642a0219708426c6"},
-    {file = "bitarray-2.7.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8357f74c5b0629bbcdc2e38265c7cfb00542baabbbc60a7bec217531ba780e78"},
-    {file = "bitarray-2.7.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:650564f4d0a77189a47bd619fcac8feaa0e79f5f7e3e19a60f55ccf1f44a2023"},
-    {file = "bitarray-2.7.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2dcd3e54579042764d56cdefc84d9c873be6678393a56e5adf6ec0bfbc43c0d"},
-    {file = "bitarray-2.7.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e918898d81803b1d3e29955e00cb640dae716080ef01d8454f3cfd9a85030819"},
-    {file = "bitarray-2.7.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0f6e02cdabdc9de9a5722cab8cc4415dd58b0af8b4c0310f5049f6b242242f64"},
-    {file = "bitarray-2.7.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:3dde864b003eecf49436bef4dbebc7494c328301fb47cf92bda02ab47802c9a9"},
-    {file = "bitarray-2.7.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:5565dd567f4552cab17b3326c5fd45b1f0176665a0ea5a1ac7fc1c84a505bd3b"},
-    {file = "bitarray-2.7.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:e85e4294e9e5fd25e37973ea0d6ceca8a599be28e203e5e81449e471d42db30d"},
-    {file = "bitarray-2.7.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d4239e4f77e0cbde4ef876fdfdfd04f84dbd1e321c1b69705a3d8f6f205fe9e4"},
-    {file = "bitarray-2.7.2-cp39-cp39-win32.whl", hash = "sha256:637eada6f1ecbd1bfd4e74c84c97530a81dfa9e7b425de8a84345a20e46f459b"},
-    {file = "bitarray-2.7.2-cp39-cp39-win_amd64.whl", hash = "sha256:5a67b520b51779376e15939ee95d83730404088adfb1d2ed6105a5b466e341c0"},
-    {file = "bitarray-2.7.2.tar.gz", hash = "sha256:7ea42120162bc089a169c58039ce2f0198b5d9bb6cac7c076c3035176335811c"},
-]
-
-[[package]]
-name = "bitarray-hardbyte"
-version = "2.3.8"
-description = "efficient arrays of booleans -- C extension"
-category = "main"
-optional = false
-python-versions = "*"
-files = [
-    {file = "bitarray-hardbyte-2.3.8.tar.gz", hash = "sha256:4eefd2460ffc4c3026287abb02908c85b562c3fb2154d8a5ab27a00a34346b76"},
-    {file = "bitarray_hardbyte-2.3.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f8859eff103728039b7e8bc4b7bbaf398add7fb475c87183e1a7324302ddb4f1"},
-    {file = "bitarray_hardbyte-2.3.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59f64764c0dbb454ae7533be7e6eeb5317f7aa77f86436d76eaf19afbf553035"},
-    {file = "bitarray_hardbyte-2.3.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:862cef53e5220b091cf85308db24671daef0d726bcab170ef2fa5dc4979efb6c"},
-    {file = "bitarray_hardbyte-2.3.8-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:1045f6704399ea58f438adcf73bcbecb8464c723ed0afc014685ed884fd2afcc"},
-    {file = "bitarray_hardbyte-2.3.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:01a8db883bbf0528845dfca7d984c2a7b369daa849645e9a4cec2324d1188c16"},
-    {file = "bitarray_hardbyte-2.3.8-cp310-cp310-win32.whl", hash = "sha256:49989ecdd7e46b1991e18d678f0e90ab8ccd6c58d046fdd9c159063851634211"},
-    {file = "bitarray_hardbyte-2.3.8-cp310-cp310-win_amd64.whl", hash = "sha256:b196be58ad567fc066d4970b4d57b7f7d2671dc65e2bbfcff453d39b5caced33"},
-    {file = "bitarray_hardbyte-2.3.8-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:905206fadc45d33dc768168c678910555445ac5eced92cc1fab28fd5881d817f"},
-    {file = "bitarray_hardbyte-2.3.8-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ea8695caa23d1e65b9d39dcd6e00707a55e5c5a0a7e91492140672e4aeec8c"},
-    {file = "bitarray_hardbyte-2.3.8-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29a6d57768b35a5998390ef9629f064111360e615cdde3c34df2ded7c8a333e"},
-    {file = "bitarray_hardbyte-2.3.8-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:39da738a22a754ed3fe92f972206b6b108e5bbf30a167663f1e194eaa367f353"},
-    {file = "bitarray_hardbyte-2.3.8-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:6d7f52f64a7527807a1f902470a6f05264c78b15582df55f7167c2efc6e48465"},
-    {file = "bitarray_hardbyte-2.3.8-cp36-cp36m-win32.whl", hash = "sha256:1d24eccde648bae478af57b79584803f697da3887c51135348a10a2d414a8c76"},
-    {file = "bitarray_hardbyte-2.3.8-cp36-cp36m-win_amd64.whl", hash = "sha256:d812315150ceb9f8db4c0c700b1d3bf41d76514157c8362410515cabcc5c051c"},
-    {file = "bitarray_hardbyte-2.3.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b92eabfa4943817511f76eea3b229559088216f6fd1766943288b4d0429396cf"},
-    {file = "bitarray_hardbyte-2.3.8-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2df6c0c739c8d39c716c2e81b3b300b8a8f3121d2da0f8a60c8c5cf6f7f1918"},
-    {file = "bitarray_hardbyte-2.3.8-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fbded89fb76b2e7d3ef8adf1aee6fd755484837875a72e22318c9d7e46c010f"},
-    {file = "bitarray_hardbyte-2.3.8-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:3ebd0a00e8b697e09cd59555759e91bc5fb082b0255ecc3cebf08f32ad1e1452"},
-    {file = "bitarray_hardbyte-2.3.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:f511c4489bff57a4efc6e9c0cf5239397a17eda80f9bf4d26b89e68da388b539"},
-    {file = "bitarray_hardbyte-2.3.8-cp37-cp37m-win32.whl", hash = "sha256:ba802254d852a0748a95ddc8769f9e9632602fc47869b193313c51ab47049778"},
-    {file = "bitarray_hardbyte-2.3.8-cp37-cp37m-win_amd64.whl", hash = "sha256:6a17314cae20566bf71571f40df78c3d6b6ec2207a0a02da13e9e5bae2651b8f"},
-    {file = "bitarray_hardbyte-2.3.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d72502174b9f4d9cf4d7eaafa867a2c56adeed469516ff95ebce595d364dbada"},
-    {file = "bitarray_hardbyte-2.3.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:110c0bb3535adac81468792fef2a38da95bd012943e4d0721bf1c92edc9e33d4"},
-    {file = "bitarray_hardbyte-2.3.8-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ac6a3e9fb58b7e487b29b6142d79a0e24c175d2dcb11c5a275a8c8181e794eb"},
-    {file = "bitarray_hardbyte-2.3.8-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:651fd46feab9f068fb6a45a1f04bae1dc26557b7f69579006ff0246285d2595e"},
-    {file = "bitarray_hardbyte-2.3.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d8f1c94bf7bb932c6dcbc092ae6263e4df2ee395340d4e2791ccb6ab484179e5"},
-    {file = "bitarray_hardbyte-2.3.8-cp38-cp38-win32.whl", hash = "sha256:4b4a3cf2594d7e2ea076f4cee7ccbfadbd27f716b354449abe5dbc9a1de9f959"},
-    {file = "bitarray_hardbyte-2.3.8-cp38-cp38-win_amd64.whl", hash = "sha256:b0e70b42c759236facfa34f7cde7b0a7d31fbbb496b9573046b59311a8cd7653"},
-    {file = "bitarray_hardbyte-2.3.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9ffa5b5403206b5afcc8a1073c9d2aa04a33c1fd3280b60a5cafb60c42980692"},
-    {file = "bitarray_hardbyte-2.3.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e481f25ae5420158c728fd555a83c5742c3d3653a9628b50d63849823c941385"},
-    {file = "bitarray_hardbyte-2.3.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:521c828d40211f078f8c8aedcc2fb94895b42d27e2b55c50286c868687f1eadb"},
-    {file = "bitarray_hardbyte-2.3.8-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:bcc5999c329bda5e55ded1d69d25b608dca30098f9b8fd0b16ac0b7890485f0c"},
-    {file = "bitarray_hardbyte-2.3.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8bff8fd11c0ff4e74a0ea5691b3077cc39576c939c2f41a69565076c90205dfb"},
-    {file = "bitarray_hardbyte-2.3.8-cp39-cp39-win32.whl", hash = "sha256:bcca35b6e86aee8f80e6a96b5e931b2a12dc4e25a80bb414c024c05506dad921"},
-    {file = "bitarray_hardbyte-2.3.8-cp39-cp39-win_amd64.whl", hash = "sha256:6c41f0ef66a4067bb0fee74ab153f00713f4d83906638bae1c6bae916daae256"},
-    {file = "bitarray_hardbyte-2.3.8-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:68f56c9d9fea24978f85c4f474d76f50a688f75be0d0dce5eea624f63dca7ee7"},
-    {file = "bitarray_hardbyte-2.3.8-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84ba65d51dd0c21cf47b80ac50fa2280205794c840ae736aa50c15194a2c64ae"},
-    {file = "bitarray_hardbyte-2.3.8-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8459b660e07a04e06379e85b6352673c0a9c3b484bba3d61416a7777f6deeace"},
-    {file = "bitarray_hardbyte-2.3.8-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:eebf6216cd6dfb93212f03453fff4f2633c4ee4da7016c9d4b10a0a674a7297f"},
-    {file = "bitarray_hardbyte-2.3.8-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:12c239cb1de8bd597ae3255ad583cac8b952d5529e28d3f884730443650f0702"},
-    {file = "bitarray_hardbyte-2.3.8-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ebc8c8a45715cce225b8ce8f7ca82979bbfc7b90b29ea25ebad61636c46c360b"},
-    {file = "bitarray_hardbyte-2.3.8-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c830001e806de2fd221ddab796eecce3f4b5923a403cf6d5bcb9d3c0c1129825"},
-    {file = "bitarray_hardbyte-2.3.8-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:83d5befbc46b961acef93a996837f7deda73a3b8e1b7c3675578a25398e655b5"},
+    {file = "bitarray-2.7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:979d42e0b2c3113526f9716a461e08671788a23ce7e3b5cd090ce3e6a6762641"},
+    {file = "bitarray-2.7.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:860edf8533223d82bd6201894bcaf540f828f49075f363390eecf04b12fb94cb"},
+    {file = "bitarray-2.7.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:78378d8dacbe1f4f263347f42ec0a41cc2097cd671c6ac30a65a838284a5e141"},
+    {file = "bitarray-2.7.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:888df211aafe5fad41c0792a686d95c8ba37345d5037f437aa3c09608f9c3b56"},
+    {file = "bitarray-2.7.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fb3f003dee96dbf24a6df71443557f249b17b20083c189995302b14eb01530bf"},
+    {file = "bitarray-2.7.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c531532c21bc1063e65957a1a85a2d13601ec21801f70821c89d9339b16ebc78"},
+    {file = "bitarray-2.7.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b8fd92c8026e4ba6874e94f538890e35bef2a3a18ea54e3663c578b7916ade1"},
+    {file = "bitarray-2.7.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6d19c34a2121eccfeb642d4ad71163bd3342a8f3a99e6724fe824bdfbc0a5b65"},
+    {file = "bitarray-2.7.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:102db74ee82ec5774aba01481e73eedaebd27ba167344a81d3b42e6fbf9ffb77"},
+    {file = "bitarray-2.7.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:7f6540b45b2230442f7a0614745131e0a6f28251f5d33ac19d0ed61d80db7153"},
+    {file = "bitarray-2.7.3-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:99c9345c417a9cff98f9f6e59b0350dcc10c2e0e1ea66acf7946de1cd60541fa"},
+    {file = "bitarray-2.7.3-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:a1d439c98e65ab8e5fbcc2b242a16e7a3f076974bff78185ff42ba2d4c220032"},
+    {file = "bitarray-2.7.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:87897ec0e4876c9f2c1ae313519de0ed2ad8041a4d2210a083f9b4a239add2e3"},
+    {file = "bitarray-2.7.3-cp310-cp310-win32.whl", hash = "sha256:cb46c3a4002c8322dd0e1b4b53f8a647dcb0f199f5c7a1fc03d3880c3eabbd2c"},
+    {file = "bitarray-2.7.3-cp310-cp310-win_amd64.whl", hash = "sha256:5df10eb9b794932b0cf806f412d1c6d04fb7655ca7ae5caf6354b9edc380a5f7"},
+    {file = "bitarray-2.7.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:27524bc92fdeb464a5057a4677a35f482cf30be2e920bd1d11c46de533cafda6"},
+    {file = "bitarray-2.7.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3cf37431de779b29e5c0d8e36868f77f6df53c3c19c20e8404137e257dc80040"},
+    {file = "bitarray-2.7.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8abd23f94cdcce971d932a5f0a066d40fbc61901fd087aa70d32cccd1793bd20"},
+    {file = "bitarray-2.7.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7659bdfe7716b14a39007e31e957fa64d7f0d9e40a1dbd024bd81b972d76bffb"},
+    {file = "bitarray-2.7.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:da1570f301abdfda68f4fdb40c4d3f09af4bb6e4550b4fa5395db0d142b680bc"},
+    {file = "bitarray-2.7.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8becbb9649fd29ee577f9f0405ce2fba5cf9fa2c290c9b044bc235c04473f213"},
+    {file = "bitarray-2.7.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72fd7f6f940bc42914c86700591ccfd1daeff0e414cefcbd7843117df2fac4e9"},
+    {file = "bitarray-2.7.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:23b7bada6d6b62cba08f4a1b8a95da2d8592aae1db3c167dcb52abcba0a7bef5"},
+    {file = "bitarray-2.7.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4b2d150a81a981537801ac7d4f4f5d082c48343612a21f4e2c4cd2e887973bd5"},
+    {file = "bitarray-2.7.3-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:1502660ab489b1f18c3493c766252cd5d24bc1cbf4bdf3594e0a30de142ed453"},
+    {file = "bitarray-2.7.3-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:91f43f6b6c9129a56d3e2dccb8b88ffce0e4f4893dd9d69d285676bdf5b9ca14"},
+    {file = "bitarray-2.7.3-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:a69c99274aee2ffdc7f1cfd34044ccb7155790d6f5217d677ea46a6ddead6dd2"},
+    {file = "bitarray-2.7.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d63f20299441e32171f08fc62f7ea7e401cc12a96f67a36ab2d76439ecfcb118"},
+    {file = "bitarray-2.7.3-cp311-cp311-win32.whl", hash = "sha256:0b84fd9dbf999cbca1090a7703aa1404cd01af4035c6ba3adf69d41280611fb6"},
+    {file = "bitarray-2.7.3-cp311-cp311-win_amd64.whl", hash = "sha256:76bbbb9ceebb9cbb2b14369b3681fecab226792b339f612e79f6575ca31fed45"},
+    {file = "bitarray-2.7.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50d5e2c026b3e3d145f64c457338ea99edcbdd302fdcbd96418251ac51a98a59"},
+    {file = "bitarray-2.7.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7d571056115bbdc18f199a9ee4c2a1b5884f5e63a3c05fe43d2fc7fc67320515"},
+    {file = "bitarray-2.7.3-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e2a0313657e6656efca2148cfc91c50fdafca6f811b6c7d0906e6ba57134e560"},
+    {file = "bitarray-2.7.3-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d3b5abb73c45d40d27f9795dac9d6eb1515729c13f93dd67df2be07be6549990"},
+    {file = "bitarray-2.7.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7776c070943f45cd8303543a6625cf82f2e000ef9c885d52d7828be099e52f42"},
+    {file = "bitarray-2.7.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:057f9c53a34e42deed6e8813a82b9c85924f4728be28e3b9b65144569ac5a387"},
+    {file = "bitarray-2.7.3-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:8591ad5768860ad186dc94fd58b2932604a7639b57eefbbff2b4865af3407691"},
+    {file = "bitarray-2.7.3-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:bd7f4b2df89bf4e298756c0be0be67fb84d6aa49bda60d46805d43f0e643abd5"},
+    {file = "bitarray-2.7.3-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:433f91c8ab8338662aaa86b0677e6c15c35f8f7b65d4c43d7d1647a8198bc0b0"},
+    {file = "bitarray-2.7.3-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:31e60d8341c3189aa156ca8cb2f6370b29d79cf132e3d091714b0a5a9097eb69"},
+    {file = "bitarray-2.7.3-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:ea33ed09157e032f0a7a2627ef87f156e9927697f59b55961439d34bf45af23a"},
+    {file = "bitarray-2.7.3-cp36-cp36m-win32.whl", hash = "sha256:302149aaff75939beb8af7f32ac9bf922480033a24fb54f4ebc0c9dc175247c4"},
+    {file = "bitarray-2.7.3-cp36-cp36m-win_amd64.whl", hash = "sha256:7a8995737fae8de03b31ed83acf4f4326a55b217022009d18be19ff87fc9010e"},
+    {file = "bitarray-2.7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8b2f31a4cc28aef27355ab896e4b4cc2da2204b2b7adb674d8be7fefa0c93868"},
+    {file = "bitarray-2.7.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5df624ee8a4098c3b1149f4817f2a4a0121c4920e1c114af324bc52d6659e2b"},
+    {file = "bitarray-2.7.3-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cb1d60ed709989e34e7158d97fdb077a2f2dfc505998a84161a70f81a6101172"},
+    {file = "bitarray-2.7.3-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:748847e58c45a37f23db1f53a6dc16ae32aa80ee504653d79336830de1a79ed7"},
+    {file = "bitarray-2.7.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4b7fdb9772e087174f446655bbc497a1600b5758f279c6d44fcf344c13d5c8a"},
+    {file = "bitarray-2.7.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:86e9c48ffeddb0f943e87ab65e1e95dccc9b44ef3761af3bf9642973ab7646d2"},
+    {file = "bitarray-2.7.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:0d1f49cc51919d6fa0f7eebd073d2c620b80079aa537d084a7fafb46a35c7a4d"},
+    {file = "bitarray-2.7.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:b43d56c7c96f5a055f4051be426496db2a616840645d0ab3733d5ceacb2f701b"},
+    {file = "bitarray-2.7.3-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:01f8d02c3eae82c98d4259777cb2f042a0b3989d7dceeb37c643cb94b91d5a42"},
+    {file = "bitarray-2.7.3-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:d089b1d0b157c9a484f8f7475eecea813d0dc3818adc5bf352903da14fe88fc3"},
+    {file = "bitarray-2.7.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:1362e9fb78ca72aa52ec1f1fbd62872801302001b0156ed2a1e707850cd30ffd"},
+    {file = "bitarray-2.7.3-cp37-cp37m-win32.whl", hash = "sha256:2cdf5700537e5aa4ec9f4a0b498b8d5b03b9859d503e01ea17a6a134a838aa30"},
+    {file = "bitarray-2.7.3-cp37-cp37m-win_amd64.whl", hash = "sha256:1e1553933f4533040491f4e4499bcbbfcee42c4056f56d7e18010e779daab33d"},
+    {file = "bitarray-2.7.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:1048a29b3d72b1821a3ae9e8d64e71ed96c53a1a36b1da6db02091a424a8f795"},
+    {file = "bitarray-2.7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:10dc358fe29d7a4c5be78ab2fb5aa50cb8066babd23e0b5589eb68e26afe58d8"},
+    {file = "bitarray-2.7.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8ab6770833976448a9a973bc0df63adedc4c30de4774cec5a9928fc496423ebb"},
+    {file = "bitarray-2.7.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4abe2f829f6f2d330bccf1bcde2192264ab9a15d6d00e507265f46dc66557014"},
+    {file = "bitarray-2.7.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:87851a82bdf849e3c40ff6d8af5f734634e17f52a8f7f7e74486c2f8ce717578"},
+    {file = "bitarray-2.7.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a5fc2512bdf5289a1412c936c65d17881d2b46edb0036c63a8d5605dc8d398a3"},
+    {file = "bitarray-2.7.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1289f408a8b5c87cdb4fd7975d4021c6e61209ccb956d0411e72bf43c7f78463"},
+    {file = "bitarray-2.7.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9ee181cc00aaba38d9812f4df4e7d828105b6dde3b068cd2c43f1d8f395e0046"},
+    {file = "bitarray-2.7.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:00e93f70cbcbeabd1e79accf1b6f5b2424cd40556e7877f618549523d0031c98"},
+    {file = "bitarray-2.7.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:3fb6a952796d16c3a309d866eef56a8f4e5591d112c22446e67d33ecb096b44b"},
+    {file = "bitarray-2.7.3-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:0fe747a134f7f5bc0877eee58090ae7e7f23628eeb459f681ade65719c3f246a"},
+    {file = "bitarray-2.7.3-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:2c1b2c91bf991b5c641faee78dd5a751dff6155ec51c7a6c7f922dc85431898e"},
+    {file = "bitarray-2.7.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c3956ae54285ab30d802756144887e30e013f81c9f03e5ffff9daa46d8ca0154"},
+    {file = "bitarray-2.7.3-cp38-cp38-win32.whl", hash = "sha256:00a6fc4355bd4e6ead54d05187dc4ea39f0af439b336ae113f0194673ed730ae"},
+    {file = "bitarray-2.7.3-cp38-cp38-win_amd64.whl", hash = "sha256:305e6f7441c007f296644ba3899c0306ce9fd7a482dbbc06b6e7b7bd6e0ddabc"},
+    {file = "bitarray-2.7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:fe80c23409efb41b86efb5e45f334420a9b5b7828f5b3d08b5ff28f03a024d9e"},
+    {file = "bitarray-2.7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:16345146b61e93ca20679c83537ccf7245f78b17035f5b1a436fd2b75da04c5e"},
+    {file = "bitarray-2.7.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1af9b720a048c69e999094e2310138b7cfca5471a9d2c1dbe4b53dd10e516720"},
+    {file = "bitarray-2.7.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:088e6e9ea7f0eaf8b672679a68096dbc0a7a7b7a4ed567860f7362e1588370a6"},
+    {file = "bitarray-2.7.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:122cd70ee0de2cc9d94da8b8ebcb7dca12b9f4d3beefb94c11e110e1d87503bb"},
+    {file = "bitarray-2.7.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cb9a8ee23416bd0cfd457118978bc2f6f02c20b95336db486887f670bf92c2b7"},
+    {file = "bitarray-2.7.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a544f99c24b6f658907eb9edf290a9c54f4106738b2ab84cd19dc6013cc3abf"},
+    {file = "bitarray-2.7.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:980f6564218f853a9341fb045446539d4153338926ed2fb222e86dc9b2ae9b8f"},
+    {file = "bitarray-2.7.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f64abe9301b918d2c352e42198cea0196f3639bc1ad23a4a9d8ae97f66068901"},
+    {file = "bitarray-2.7.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:029c724bf38c6616b90b1c423b846b63f8d607ed5a23d270e3862696d88a5392"},
+    {file = "bitarray-2.7.3-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:16cb00911584a6e9ca0f42c305714898120dc6bfbbec90dacedeed4690331a47"},
+    {file = "bitarray-2.7.3-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:699b0134e87c0c4e3b224d879d218c4385a06e6b72df73b4c9c9d549155fb837"},
+    {file = "bitarray-2.7.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:b508e1bba4ec68fd0ef28505e2dad2f56de7df710c8334c97036705a562cb908"},
+    {file = "bitarray-2.7.3-cp39-cp39-win32.whl", hash = "sha256:4b84230624d15868e407ba8b66df54fc69ee6a9e9cb6d51eb264b8f2614596f1"},
+    {file = "bitarray-2.7.3-cp39-cp39-win_amd64.whl", hash = "sha256:757a08bf0aed5a650a399f8c66bcba00c210bce34408b6d7b09b4837bee8f4da"},
+    {file = "bitarray-2.7.3.tar.gz", hash = "sha256:f71256a32609b036adad932e1228b66a6b4e2cae6be397e588ddc0babd9a78b9"},
 ]
 
 [[package]]
@@ -425,22 +371,27 @@ css = ["tinycss2 (>=1.1.0,<1.2)"]
 
 [[package]]
 name = "blocklib"
-version = "0.1.7"
+version = "0.1.9"
 description = "A library for blocking in record linkage"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.8,<3.12"
 files = [
-    {file = "blocklib-0.1.7-py3-none-any.whl", hash = "sha256:399506cdd19d7d5bd1dd670cb273ee1130239b68ad6e5e4aae3bb70f5c18a15e"},
-    {file = "blocklib-0.1.7.tar.gz", hash = "sha256:cc2dde1a226a6e16a96b0e27ccf711258e56c1943d86874a261b09e40d654ef3"},
+    {file = "blocklib-0.1.9-py3-none-any.whl", hash = "sha256:61eef1910791f065ed4ff9e897696b43138dc04ace241f79a775afa68eb1ef61"},
+    {file = "blocklib-0.1.9.tar.gz", hash = "sha256:2a8e0d5e8add59218e1b74bcd4977820392a958572fef539a1722a1554f37b06"},
 ]
 
 [package.dependencies]
-bitarray-hardbyte = ">=1.2"
-jsonschema = ">=3.1"
-metaphone = ">=0.6"
-numpy = ">=1.17"
-tqdm = ">=4.36.1"
+bitarray = ">=2.4.0,<3.0.0"
+jsonschema = ">=3.1,<5.0"
+metaphone = ">=0.6,<0.7"
+numpy = ">=1.20.1,<2.0.0"
+pydantic = ">=1.8,<2.0"
+tqdm = ">=4.36.1,<5.0.0"
+typing_extensions = ">=3.7.4,<5.0.0"
+
+[package.extras]
+docs = ["Sphinx (>=4.1.0,<5.0.0)", "nbsphinx (>=0.8.2,<0.9.0)", "nbval (>=0.9.6,<0.10.0)", "notebook (>=6.2.0,<7.0.0)", "pandas (>=1.3.5,<2.0.0)"]
 
 [[package]]
 name = "certifi"
@@ -708,63 +659,63 @@ test = ["pytest"]
 
 [[package]]
 name = "coverage"
-version = "7.1.0"
+version = "7.2.1"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "coverage-7.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3b946bbcd5a8231383450b195cfb58cb01cbe7f8949f5758566b881df4b33baf"},
-    {file = "coverage-7.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ec8e767f13be637d056f7e07e61d089e555f719b387a7070154ad80a0ff31801"},
-    {file = "coverage-7.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4a5a5879a939cb84959d86869132b00176197ca561c664fc21478c1eee60d75"},
-    {file = "coverage-7.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b643cb30821e7570c0aaf54feaf0bfb630b79059f85741843e9dc23f33aaca2c"},
-    {file = "coverage-7.1.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32df215215f3af2c1617a55dbdfb403b772d463d54d219985ac7cd3bf124cada"},
-    {file = "coverage-7.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:33d1ae9d4079e05ac4cc1ef9e20c648f5afabf1a92adfaf2ccf509c50b85717f"},
-    {file = "coverage-7.1.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:29571503c37f2ef2138a306d23e7270687c0efb9cab4bd8038d609b5c2393a3a"},
-    {file = "coverage-7.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:63ffd21aa133ff48c4dff7adcc46b7ec8b565491bfc371212122dd999812ea1c"},
-    {file = "coverage-7.1.0-cp310-cp310-win32.whl", hash = "sha256:4b14d5e09c656de5038a3f9bfe5228f53439282abcab87317c9f7f1acb280352"},
-    {file = "coverage-7.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:8361be1c2c073919500b6601220a6f2f98ea0b6d2fec5014c1d9cfa23dd07038"},
-    {file = "coverage-7.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:da9b41d4539eefd408c46725fb76ecba3a50a3367cafb7dea5f250d0653c1040"},
-    {file = "coverage-7.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c5b15ed7644ae4bee0ecf74fee95808dcc34ba6ace87e8dfbf5cb0dc20eab45a"},
-    {file = "coverage-7.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d12d076582507ea460ea2a89a8c85cb558f83406c8a41dd641d7be9a32e1274f"},
-    {file = "coverage-7.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2617759031dae1bf183c16cef8fcfb3de7617f394c813fa5e8e46e9b82d4222"},
-    {file = "coverage-7.1.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c4e4881fa9e9667afcc742f0c244d9364d197490fbc91d12ac3b5de0bf2df146"},
-    {file = "coverage-7.1.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:9d58885215094ab4a86a6aef044e42994a2bd76a446dc59b352622655ba6621b"},
-    {file = "coverage-7.1.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:ffeeb38ee4a80a30a6877c5c4c359e5498eec095878f1581453202bfacc8fbc2"},
-    {file = "coverage-7.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3baf5f126f30781b5e93dbefcc8271cb2491647f8283f20ac54d12161dff080e"},
-    {file = "coverage-7.1.0-cp311-cp311-win32.whl", hash = "sha256:ded59300d6330be27bc6cf0b74b89ada58069ced87c48eaf9344e5e84b0072f7"},
-    {file = "coverage-7.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:6a43c7823cd7427b4ed763aa7fb63901ca8288591323b58c9cd6ec31ad910f3c"},
-    {file = "coverage-7.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7a726d742816cb3a8973c8c9a97539c734b3a309345236cd533c4883dda05b8d"},
-    {file = "coverage-7.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc7c85a150501286f8b56bd8ed3aa4093f4b88fb68c0843d21ff9656f0009d6a"},
-    {file = "coverage-7.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f5b4198d85a3755d27e64c52f8c95d6333119e49fd001ae5798dac872c95e0f8"},
-    {file = "coverage-7.1.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ddb726cb861c3117a553f940372a495fe1078249ff5f8a5478c0576c7be12050"},
-    {file = "coverage-7.1.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:51b236e764840a6df0661b67e50697aaa0e7d4124ca95e5058fa3d7cbc240b7c"},
-    {file = "coverage-7.1.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:7ee5c9bb51695f80878faaa5598040dd6c9e172ddcf490382e8aedb8ec3fec8d"},
-    {file = "coverage-7.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c31b75ae466c053a98bf26843563b3b3517b8f37da4d47b1c582fdc703112bc3"},
-    {file = "coverage-7.1.0-cp37-cp37m-win32.whl", hash = "sha256:3b155caf3760408d1cb903b21e6a97ad4e2bdad43cbc265e3ce0afb8e0057e73"},
-    {file = "coverage-7.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2a60d6513781e87047c3e630b33b4d1e89f39836dac6e069ffee28c4786715f5"},
-    {file = "coverage-7.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f2cba5c6db29ce991029b5e4ac51eb36774458f0a3b8d3137241b32d1bb91f06"},
-    {file = "coverage-7.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:beeb129cacea34490ffd4d6153af70509aa3cda20fdda2ea1a2be870dfec8d52"},
-    {file = "coverage-7.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c45948f613d5d18c9ec5eaa203ce06a653334cf1bd47c783a12d0dd4fd9c851"},
-    {file = "coverage-7.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ef382417db92ba23dfb5864a3fc9be27ea4894e86620d342a116b243ade5d35d"},
-    {file = "coverage-7.1.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c7c0d0827e853315c9bbd43c1162c006dd808dbbe297db7ae66cd17b07830f0"},
-    {file = "coverage-7.1.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e5cdbb5cafcedea04924568d990e20ce7f1945a1dd54b560f879ee2d57226912"},
-    {file = "coverage-7.1.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:9817733f0d3ea91bea80de0f79ef971ae94f81ca52f9b66500c6a2fea8e4b4f8"},
-    {file = "coverage-7.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:218fe982371ac7387304153ecd51205f14e9d731b34fb0568181abaf7b443ba0"},
-    {file = "coverage-7.1.0-cp38-cp38-win32.whl", hash = "sha256:04481245ef966fbd24ae9b9e537ce899ae584d521dfbe78f89cad003c38ca2ab"},
-    {file = "coverage-7.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:8ae125d1134bf236acba8b83e74c603d1b30e207266121e76484562bc816344c"},
-    {file = "coverage-7.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2bf1d5f2084c3932b56b962a683074a3692bce7cabd3aa023c987a2a8e7612f6"},
-    {file = "coverage-7.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:98b85dd86514d889a2e3dd22ab3c18c9d0019e696478391d86708b805f4ea0fa"},
-    {file = "coverage-7.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38da2db80cc505a611938d8624801158e409928b136c8916cd2e203970dde4dc"},
-    {file = "coverage-7.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3164d31078fa9efe406e198aecd2a02d32a62fecbdef74f76dad6a46c7e48311"},
-    {file = "coverage-7.1.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db61a79c07331e88b9a9974815c075fbd812bc9dbc4dc44b366b5368a2936063"},
-    {file = "coverage-7.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9ccb092c9ede70b2517a57382a601619d20981f56f440eae7e4d7eaafd1d1d09"},
-    {file = "coverage-7.1.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:33ff26d0f6cc3ca8de13d14fde1ff8efe1456b53e3f0273e63cc8b3c84a063d8"},
-    {file = "coverage-7.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d47dd659a4ee952e90dc56c97d78132573dc5c7b09d61b416a9deef4ebe01a0c"},
-    {file = "coverage-7.1.0-cp39-cp39-win32.whl", hash = "sha256:d248cd4a92065a4d4543b8331660121b31c4148dd00a691bfb7a5cdc7483cfa4"},
-    {file = "coverage-7.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:7ed681b0f8e8bcbbffa58ba26fcf5dbc8f79e7997595bf071ed5430d8c08d6f3"},
-    {file = "coverage-7.1.0-pp37.pp38.pp39-none-any.whl", hash = "sha256:755e89e32376c850f826c425ece2c35a4fc266c081490eb0a841e7c1cb0d3bda"},
-    {file = "coverage-7.1.0.tar.gz", hash = "sha256:10188fe543560ec4874f974b5305cd1a8bdcfa885ee00ea3a03733464c4ca265"},
+    {file = "coverage-7.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:49567ec91fc5e0b15356da07a2feabb421d62f52a9fff4b1ec40e9e19772f5f8"},
+    {file = "coverage-7.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d2ef6cae70168815ed91388948b5f4fcc69681480a0061114db737f957719f03"},
+    {file = "coverage-7.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3004765bca3acd9e015794e5c2f0c9a05587f5e698127ff95e9cfba0d3f29339"},
+    {file = "coverage-7.2.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cca7c0b7f5881dfe0291ef09ba7bb1582cb92ab0aeffd8afb00c700bf692415a"},
+    {file = "coverage-7.2.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b2167d116309f564af56f9aa5e75ef710ef871c5f9b313a83050035097b56820"},
+    {file = "coverage-7.2.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:cb5f152fb14857cbe7f3e8c9a5d98979c4c66319a33cad6e617f0067c9accdc4"},
+    {file = "coverage-7.2.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:87dc37f16fb5e3a28429e094145bf7c1753e32bb50f662722e378c5851f7fdc6"},
+    {file = "coverage-7.2.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e191a63a05851f8bce77bc875e75457f9b01d42843f8bd7feed2fc26bbe60833"},
+    {file = "coverage-7.2.1-cp310-cp310-win32.whl", hash = "sha256:e3ea04b23b114572b98a88c85379e9e9ae031272ba1fb9b532aa934c621626d4"},
+    {file = "coverage-7.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:0cf557827be7eca1c38a2480484d706693e7bb1929e129785fe59ec155a59de6"},
+    {file = "coverage-7.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:570c21a29493b350f591a4b04c158ce1601e8d18bdcd21db136fbb135d75efa6"},
+    {file = "coverage-7.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9e872b082b32065ac2834149dc0adc2a2e6d8203080501e1e3c3c77851b466f9"},
+    {file = "coverage-7.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fac6343bae03b176e9b58104a9810df3cdccd5cfed19f99adfa807ffbf43cf9b"},
+    {file = "coverage-7.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abacd0a738e71b20e224861bc87e819ef46fedba2fb01bc1af83dfd122e9c319"},
+    {file = "coverage-7.2.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d9256d4c60c4bbfec92721b51579c50f9e5062c21c12bec56b55292464873508"},
+    {file = "coverage-7.2.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:80559eaf6c15ce3da10edb7977a1548b393db36cbc6cf417633eca05d84dd1ed"},
+    {file = "coverage-7.2.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:0bd7e628f6c3ec4e7d2d24ec0e50aae4e5ae95ea644e849d92ae4805650b4c4e"},
+    {file = "coverage-7.2.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:09643fb0df8e29f7417adc3f40aaf379d071ee8f0350ab290517c7004f05360b"},
+    {file = "coverage-7.2.1-cp311-cp311-win32.whl", hash = "sha256:1b7fb13850ecb29b62a447ac3516c777b0e7a09ecb0f4bb6718a8654c87dfc80"},
+    {file = "coverage-7.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:617a94ada56bbfe547aa8d1b1a2b8299e2ec1ba14aac1d4b26a9f7d6158e1273"},
+    {file = "coverage-7.2.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8649371570551d2fd7dee22cfbf0b61f1747cdfb2b7587bb551e4beaaa44cb97"},
+    {file = "coverage-7.2.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d2b9b5e70a21474c105a133ba227c61bc95f2ac3b66861143ce39a5ea4b3f84"},
+    {file = "coverage-7.2.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae82c988954722fa07ec5045c57b6d55bc1a0890defb57cf4a712ced65b26ddd"},
+    {file = "coverage-7.2.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:861cc85dfbf55a7a768443d90a07e0ac5207704a9f97a8eb753292a7fcbdfcfc"},
+    {file = "coverage-7.2.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:0339dc3237c0d31c3b574f19c57985fcbe494280153bbcad33f2cdf469f4ac3e"},
+    {file = "coverage-7.2.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:5928b85416a388dd557ddc006425b0c37e8468bd1c3dc118c1a3de42f59e2a54"},
+    {file = "coverage-7.2.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8d3843ca645f62c426c3d272902b9de90558e9886f15ddf5efe757b12dd376f5"},
+    {file = "coverage-7.2.1-cp37-cp37m-win32.whl", hash = "sha256:6a034480e9ebd4e83d1aa0453fd78986414b5d237aea89a8fdc35d330aa13bae"},
+    {file = "coverage-7.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:6fce673f79a0e017a4dc35e18dc7bb90bf6d307c67a11ad5e61ca8d42b87cbff"},
+    {file = "coverage-7.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7f099da6958ddfa2ed84bddea7515cb248583292e16bb9231d151cd528eab657"},
+    {file = "coverage-7.2.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:97a3189e019d27e914ecf5c5247ea9f13261d22c3bb0cfcfd2a9b179bb36f8b1"},
+    {file = "coverage-7.2.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a81dbcf6c6c877986083d00b834ac1e84b375220207a059ad45d12f6e518a4e3"},
+    {file = "coverage-7.2.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:78d2c3dde4c0b9be4b02067185136b7ee4681978228ad5ec1278fa74f5ca3e99"},
+    {file = "coverage-7.2.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a209d512d157379cc9ab697cbdbb4cfd18daa3e7eebaa84c3d20b6af0037384"},
+    {file = "coverage-7.2.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f3d07edb912a978915576a776756069dede66d012baa503022d3a0adba1b6afa"},
+    {file = "coverage-7.2.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:8dca3c1706670297851bca1acff9618455122246bdae623be31eca744ade05ec"},
+    {file = "coverage-7.2.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b1991a6d64231a3e5bbe3099fb0dd7c9aeaa4275ad0e0aeff4cb9ef885c62ba2"},
+    {file = "coverage-7.2.1-cp38-cp38-win32.whl", hash = "sha256:22c308bc508372576ffa3d2dbc4824bb70d28eeb4fcd79d4d1aed663a06630d0"},
+    {file = "coverage-7.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:b0c0d46de5dd97f6c2d1b560bf0fcf0215658097b604f1840365296302a9d1fb"},
+    {file = "coverage-7.2.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4dd34a935de268a133e4741827ae951283a28c0125ddcdbcbba41c4b98f2dfef"},
+    {file = "coverage-7.2.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0f8318ed0f3c376cfad8d3520f496946977abde080439d6689d7799791457454"},
+    {file = "coverage-7.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:834c2172edff5a08d78e2f53cf5e7164aacabeb66b369f76e7bb367ca4e2d993"},
+    {file = "coverage-7.2.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e4d70c853f0546855f027890b77854508bdb4d6a81242a9d804482e667fff6e6"},
+    {file = "coverage-7.2.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a6450da4c7afc4534305b2b7d8650131e130610cea448ff240b6ab73d7eab63"},
+    {file = "coverage-7.2.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:99f4dd81b2bb8fc67c3da68b1f5ee1650aca06faa585cbc6818dbf67893c6d58"},
+    {file = "coverage-7.2.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:bdd3f2f285ddcf2e75174248b2406189261a79e7fedee2ceeadc76219b6faa0e"},
+    {file = "coverage-7.2.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f29351393eb05e6326f044a7b45ed8e38cb4dcc38570d12791f271399dc41431"},
+    {file = "coverage-7.2.1-cp39-cp39-win32.whl", hash = "sha256:e2b50ebc2b6121edf352336d503357321b9d8738bb7a72d06fc56153fd3f4cd8"},
+    {file = "coverage-7.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:bd5a12239c0006252244f94863f1c518ac256160cd316ea5c47fb1a11b25889a"},
+    {file = "coverage-7.2.1-pp37.pp38.pp39-none-any.whl", hash = "sha256:436313d129db7cf5b4ac355dd2bd3f7c7e5294af077b090b85de75f8458b8616"},
+    {file = "coverage-7.2.1.tar.gz", hash = "sha256:c77f2a9093ccf329dd523a9b2b3c854c20d2a3d968b6def3b820272ca6732242"},
 ]
 
 [package.dependencies]
@@ -961,14 +912,14 @@ tests = ["asttokens", "littleutils", "pytest", "rich"]
 
 [[package]]
 name = "fastjsonschema"
-version = "2.16.2"
+version = "2.16.3"
 description = "Fastest Python implementation of JSON schema"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "fastjsonschema-2.16.2-py3-none-any.whl", hash = "sha256:21f918e8d9a1a4ba9c22e09574ba72267a6762d47822db9add95f6454e51cc1c"},
-    {file = "fastjsonschema-2.16.2.tar.gz", hash = "sha256:01e366f25d9047816fe3d288cbfc3e10541daf0af2044763f3d0ade42476da18"},
+    {file = "fastjsonschema-2.16.3-py3-none-any.whl", hash = "sha256:04fbecc94300436f628517b05741b7ea009506ce8f946d40996567c669318490"},
+    {file = "fastjsonschema-2.16.3.tar.gz", hash = "sha256:4a30d6315a68c253cfa8f963b9697246315aa3db89f98b97235e345dedfb0b8e"},
 ]
 
 [package.extras]
@@ -1204,14 +1155,14 @@ test = ["flaky", "ipyparallel", "pre-commit", "pytest (>=7.0)", "pytest-asyncio"
 
 [[package]]
 name = "ipython"
-version = "8.10.0"
+version = "8.11.0"
 description = "IPython: Productive Interactive Computing"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "ipython-8.10.0-py3-none-any.whl", hash = "sha256:b38c31e8fc7eff642fc7c597061fff462537cf2314e3225a19c906b7b0d8a345"},
-    {file = "ipython-8.10.0.tar.gz", hash = "sha256:b13a1d6c1f5818bd388db53b7107d17454129a70de2b87481d555daede5eb49e"},
+    {file = "ipython-8.11.0-py3-none-any.whl", hash = "sha256:5b54478e459155a326bf5f42ee4f29df76258c0279c36f21d71ddb560f88b156"},
+    {file = "ipython-8.11.0.tar.gz", hash = "sha256:735cede4099dbc903ee540307b9171fbfef4aa75cfcacc5a273b2cda2f02be04"},
 ]
 
 [package.dependencies]
@@ -1223,7 +1174,7 @@ jedi = ">=0.16"
 matplotlib-inline = "*"
 pexpect = {version = ">4.3", markers = "sys_platform != \"win32\""}
 pickleshare = "*"
-prompt-toolkit = ">=3.0.30,<3.1.0"
+prompt-toolkit = ">=3.0.30,<3.0.37 || >3.0.37,<3.1.0"
 pygments = ">=2.4.0"
 stack-data = "*"
 traitlets = ">=5"
@@ -1487,14 +1438,14 @@ test = ["codecov", "coverage", "ipykernel (>=6.14)", "mypy", "paramiko", "pre-co
 
 [[package]]
 name = "jupyter-console"
-version = "6.5.1"
+version = "6.6.2"
 description = "Jupyter terminal console"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "jupyter_console-6.5.1-py3-none-any.whl", hash = "sha256:c575bb6ed56ca78189594176341e7b31426ff30fafcd22bf3dad7be309595b5e"},
-    {file = "jupyter_console-6.5.1.tar.gz", hash = "sha256:6b91b7b6e8a715053b536db209a2f4b02429d7b28db27373a56a26b0bebd620b"},
+    {file = "jupyter_console-6.6.2-py3-none-any.whl", hash = "sha256:0ba2da017be36bfae489f233f031f251da5b88b0ceafabea240b465ee474944a"},
+    {file = "jupyter_console-6.6.2.tar.gz", hash = "sha256:7385dfed8a01fd51e3c98449dae24f38c1ba015d2073835e785671653a0967fc"},
 ]
 
 [package.dependencies]
@@ -1508,7 +1459,7 @@ pyzmq = ">=17"
 traitlets = ">=5.4"
 
 [package.extras]
-test = ["pexpect", "pytest"]
+test = ["flaky", "pexpect", "pytest"]
 
 [[package]]
 name = "jupyter-core"
@@ -1663,24 +1614,24 @@ testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-chec
 
 [[package]]
 name = "markdown-it-py"
-version = "2.1.0"
+version = "2.2.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "markdown-it-py-2.1.0.tar.gz", hash = "sha256:cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da"},
-    {file = "markdown_it_py-2.1.0-py3-none-any.whl", hash = "sha256:93de681e5c021a432c63147656fe21790bc01231e0cd2da73626f1aa3ac0fe27"},
+    {file = "markdown-it-py-2.2.0.tar.gz", hash = "sha256:7c9a5e412688bc771c67432cbfebcdd686c93ce6484913dccf06cb5a0bea35a1"},
+    {file = "markdown_it_py-2.2.0-py3-none-any.whl", hash = "sha256:5a35f8d1870171d9acc47b99612dc146129b631baf04970128b568f190d0cc30"},
 ]
 
 [package.dependencies]
 mdurl = ">=0.1,<1.0"
 
 [package.extras]
-benchmarking = ["psutil", "pytest", "pytest-benchmark (>=3.2,<4.0)"]
-code-style = ["pre-commit (==2.6)"]
-compare = ["commonmark (>=0.9.1,<0.10.0)", "markdown (>=3.3.6,<3.4.0)", "mistletoe (>=0.8.1,<0.9.0)", "mistune (>=2.0.2,<2.1.0)", "panflute (>=2.1.3,<2.2.0)"]
-linkify = ["linkify-it-py (>=1.0,<2.0)"]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+code-style = ["pre-commit (>=3.0,<4.0)"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
 plugins = ["mdit-py-plugins"]
 profiling = ["gprof2dot"]
 rtd = ["attrs", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
@@ -1831,14 +1782,14 @@ test = ["pytest (<5.4)", "pytest-cov"]
 
 [[package]]
 name = "more-itertools"
-version = "9.0.0"
+version = "9.1.0"
 description = "More routines for operating on iterables, beyond itertools"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "more-itertools-9.0.0.tar.gz", hash = "sha256:5a6257e40878ef0520b1803990e3e22303a41b5714006c32a3fd8304b26ea1ab"},
-    {file = "more_itertools-9.0.0-py3-none-any.whl", hash = "sha256:250e83d7e81d0c87ca6bd942e6aeab8cc9daa6096d12c5308f3f92fa5e5c1f41"},
+    {file = "more-itertools-9.1.0.tar.gz", hash = "sha256:cabaa341ad0389ea83c17a94566a53ae4c9d07349861ecb14dc6d0345cf9ac5d"},
+    {file = "more_itertools-9.1.0-py3-none-any.whl", hash = "sha256:d2bc7f02446e86a68911e58ded76d6561eea00cddfb2a91e7019bbb586c799f3"},
 ]
 
 [[package]]
@@ -2366,14 +2317,14 @@ twisted = ["twisted"]
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.36"
+version = "3.0.38"
 description = "Library for building powerful interactive command lines in Python"
 category = "main"
 optional = false
-python-versions = ">=3.6.2"
+python-versions = ">=3.7.0"
 files = [
-    {file = "prompt_toolkit-3.0.36-py3-none-any.whl", hash = "sha256:aa64ad242a462c5ff0363a7b9cfe696c20d55d9fc60c11fd8e632d064804d305"},
-    {file = "prompt_toolkit-3.0.36.tar.gz", hash = "sha256:3e163f254bef5a03b146397d7c1963bd3e2812f0964bb9a24e6ec761fd28db63"},
+    {file = "prompt_toolkit-3.0.38-py3-none-any.whl", hash = "sha256:45ea77a2f7c60418850331366c81cf6b5b9cf4c7fd34616f733c5427e6abbb1f"},
+    {file = "prompt_toolkit-3.0.38.tar.gz", hash = "sha256:23ac5d50538a9a38c8bde05fecb47d0b403ecd0662857a86f886f798563d5b9b"},
 ]
 
 [package.dependencies]
@@ -2638,14 +2589,14 @@ six = ">=1.5"
 
 [[package]]
 name = "python-json-logger"
-version = "2.0.6"
+version = "2.0.7"
 description = "A python library adding a json log formatter"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "python-json-logger-2.0.6.tar.gz", hash = "sha256:ed33182c2b438a366775c25c1219ebbd5bd7f71694c644d6b3b3861e19565ae3"},
-    {file = "python_json_logger-2.0.6-py3-none-any.whl", hash = "sha256:3af8e5b907b4a5b53cae249205ee3a3d3472bd7ad9ddfaec136eec2f2faf4995"},
+    {file = "python-json-logger-2.0.7.tar.gz", hash = "sha256:23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c"},
+    {file = "python_json_logger-2.0.7-py3-none-any.whl", hash = "sha256:f380b826a991ebbe3de4d897aeec42760035ac760345e57b812938dc8b35e2bd"},
 ]
 
 [[package]]
@@ -3171,14 +3122,14 @@ win32 = ["pywin32"]
 
 [[package]]
 name = "setuptools"
-version = "67.3.2"
+version = "67.4.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.3.2-py3-none-any.whl", hash = "sha256:bb6d8e508de562768f2027902929f8523932fcd1fb784e6d573d2cafac995a48"},
-    {file = "setuptools-67.3.2.tar.gz", hash = "sha256:95f00380ef2ffa41d9bba85d95b27689d923c93dfbafed4aecd7cf988a25e012"},
+    {file = "setuptools-67.4.0-py3-none-any.whl", hash = "sha256:f106dee1b506dee5102cc3f3e9e68137bbad6d47b616be7991714b0c62204251"},
+    {file = "setuptools-67.4.0.tar.gz", hash = "sha256:e5fd0a713141a4a105412233c63dc4e17ba0090c8e8334594ac790ec97792330"},
 ]
 
 [package.extras]
@@ -3445,14 +3396,14 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.19.0"
+version = "20.20.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.19.0-py3-none-any.whl", hash = "sha256:54eb59e7352b573aa04d53f80fc9736ed0ad5143af445a1e539aada6eb947dd1"},
-    {file = "virtualenv-20.19.0.tar.gz", hash = "sha256:37a640ba82ed40b226599c522d411e4be5edb339a0c0de030c0dc7b646d61590"},
+    {file = "virtualenv-20.20.0-py3-none-any.whl", hash = "sha256:3c22fa5a7c7aa106ced59934d2c20a2ecb7f49b4130b8bf444178a16b880fa45"},
+    {file = "virtualenv-20.20.0.tar.gz", hash = "sha256:a8a4b8ca1e28f864b7514a253f98c1d62b64e31e77325ba279248c65fb4fcef4"},
 ]
 
 [package.dependencies]
@@ -3531,21 +3482,21 @@ files = [
 
 [[package]]
 name = "zipp"
-version = "3.14.0"
+version = "3.15.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "zipp-3.14.0-py3-none-any.whl", hash = "sha256:188834565033387710d046e3fe96acfc9b5e86cbca7f39ff69cf21a4128198b7"},
-    {file = "zipp-3.14.0.tar.gz", hash = "sha256:9e5421e176ef5ab4c0ad896624e87a7b2f07aca746c9b2aa305952800cb8eecb"},
+    {file = "zipp-3.15.0-py3-none-any.whl", hash = "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"},
+    {file = "zipp-3.15.0.tar.gz", hash = "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b"},
 ]
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "565fe8f0c775593c90ac36f5934cb4006a55bcac5af9bb15bf2b6f665f002845"
+content-hash = "f82085569e2cb24c9f681fe00d8ed46d1e1bec1871c317d2dad64fd9d364475e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ anonlink = 'anonlinkclient.cli:cli'
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
 bashplotlib = "^0.6"
-blocklib = "^0.1"
+blocklib = "^0.1.8"
 click = ">=7.1.2,<9.0.0"
 clkhash = "^0.17"
 jsonschema = ">=3.2,<5.0"


### PR DESCRIPTION
current anonlink-client does not work with blocklib 0.1.8 and above. 